### PR TITLE
Workaround to allow buildpack install from github

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -1,0 +1,1 @@
+compile.bat


### PR DESCRIPTION
Fixes:
Error: Expected a buildpack, did not find bin/compile inside /tmp/stackato-buildpack-7Bc55Var2y.zip
